### PR TITLE
fix(core): strict YYYY-MM-DD date parsing with consistent UTC semantics

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
   rules: {
     '@typescript-eslint/no-explicit-any': 'warn',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
   },
   ignorePatterns: ['dist/', 'node_modules/', '*.js', '!.eslintrc.js'],
 };

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Build core
+        run: pnpm --filter @get-skipper/core build
+
       - name: Typecheck
         run: pnpm typecheck
 

--- a/packages/core/__tests__/client.test.ts
+++ b/packages/core/__tests__/client.test.ts
@@ -96,7 +96,8 @@ describe('SheetsClient.fetchAll()', () => {
     expect(entries).toHaveLength(2);
 
     expect(entries[0].testId).toBe('tests/a.spec.ts > login');
-    expect(entries[0].disabledUntil).toEqual(new Date('2099-12-31'));
+    // "2099-12-31" is stored as next-day midnight UTC = 2100-01-01T00:00:00Z
+    expect(entries[0].disabledUntil).toEqual(new Date(Date.UTC(2099, 11, 32)));
     expect(entries[0].notes).toBe('flaky');
 
     expect(entries[1].testId).toBe('tests/b.spec.ts > checkout');
@@ -115,7 +116,7 @@ describe('SheetsClient.fetchAll()', () => {
     expect(entry.disabledUntil).toBeNull();
   });
 
-  it('returns disabledUntil: null and warns for an invalid date string', async () => {
+  it('throws for a date string that is not in YYYY-MM-DD format', async () => {
     mockValuesGet.mockResolvedValue(
       makeRows([
         ['testId', 'disabledUntil'],
@@ -123,8 +124,31 @@ describe('SheetsClient.fetchAll()', () => {
       ]),
     );
     const client = new SheetsClientCtor(inlineConfig);
+    await expect(client.fetchAll()).rejects.toThrow('must be in YYYY-MM-DD format');
+  });
+
+  it('throws for a non-padded date like "2026-4-1" (Safari-incompatible format)', async () => {
+    mockValuesGet.mockResolvedValue(
+      makeRows([
+        ['testId', 'disabledUntil'],
+        ['tests/a.spec.ts > test', '2026-4-1'],
+      ]),
+    );
+    const client = new SheetsClientCtor(inlineConfig);
+    await expect(client.fetchAll()).rejects.toThrow('must be in YYYY-MM-DD format');
+  });
+
+  it('parses a valid YYYY-MM-DD date as next-day midnight UTC for consistent timezone handling', async () => {
+    mockValuesGet.mockResolvedValue(
+      makeRows([
+        ['testId', 'disabledUntil'],
+        ['tests/a.spec.ts > test', '2026-04-01'],
+      ]),
+    );
+    const client = new SheetsClientCtor(inlineConfig);
     const { entries: [entry] } = await client.fetchAll();
-    expect(entry.disabledUntil).toBeNull();
+    // "disabled until 2026-04-01" → re-enables at 2026-04-02T00:00:00Z
+    expect(entry.disabledUntil).toEqual(new Date('2026-04-02T00:00:00.000Z'));
   });
 
   it('throws when the testId column is missing from the header', async () => {
@@ -152,7 +176,8 @@ describe('SheetsClient.fetchAll()', () => {
     });
     const { entries: [entry] } = await client.fetchAll();
     expect(entry.testId).toBe('tests/a.spec.ts > test');
-    expect(entry.disabledUntil).toEqual(new Date('2099-01-01'));
+    // "2099-01-01" → next-day midnight UTC = 2099-01-02T00:00:00Z
+    expect(entry.disabledUntil).toEqual(new Date(Date.UTC(2099, 0, 2)));
   });
 
   it('skips rows with an empty testId cell', async () => {
@@ -258,7 +283,8 @@ describe('SheetsClient.fetchAll()', () => {
       const { entries } = await client.fetchAll();
 
       expect(entries).toHaveLength(1);
-      expect(entries[0].disabledUntil).toEqual(new Date(laterDate));
+      // laterDate "2099-06-01" → 2099-06-02T00:00:00Z (next-day midnight UTC)
+      expect(entries[0].disabledUntil).toEqual(new Date(Date.UTC(2099, 5, 2)));
     });
 
     it('warns and skips reference sheets not found in metadata', async () => {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -94,14 +94,16 @@ export class SheetsClient {
       if (disabledUntilIdx !== -1 && row[disabledUntilIdx]) {
         const raw = String(row[disabledUntilIdx]).trim();
         if (raw) {
-          const parsed = new Date(raw);
-          if (!isNaN(parsed.getTime())) {
-            disabledUntil = parsed;
-          } else {
-            warn(
-              `[skipper] Row ${i + 1} in "${sheetName}": invalid date "${raw}" in "${disabledUntilCol}" — treating as enabled`,
+          if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+            throw new Error(
+              `[skipper] Row ${i + 1} in "${sheetName}": date "${raw}" in "${disabledUntilCol}" must be in YYYY-MM-DD format (e.g. "2026-04-01")`,
             );
           }
+          const [year, month, day] = raw.split('-').map(Number);
+          // Parse as midnight UTC of the next day: "disabled until 2026-04-01" keeps
+          // the test disabled through the entire calendar day in UTC and re-enables
+          // at 2026-04-02T00:00:00Z, regardless of the runner's local timezone.
+          disabledUntil = new Date(Date.UTC(year, month - 1, day + 1));
         }
       }
 

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -36,6 +36,9 @@
     "typecheck": "tsc --noEmit",
     "test": "jest --config ../../jest.config.js --testPathPattern=packages/cypress/"
   },
+  "devDependencies": {
+    "@types/node": "*"
+  },
   "dependencies": {
     "@get-skipper/core": "workspace:*"
   },

--- a/packages/playwright/src/fixtures.ts
+++ b/packages/playwright/src/fixtures.ts
@@ -22,7 +22,7 @@ type SkipperTestFixtures = {
  */
 export const test = base.extend<SkipperTestFixtures, SkipperWorkerFixtures>({
   _skipperResolver: [
-    async ({}, use) => {
+    async (_: Record<never, never>, use) => {
       const raw = fs.readFileSync(SKIPPER_CACHE_PATH, 'utf8');
       const data = JSON.parse(raw) as Record<string, string | null>;
       const resolver = SkipperResolver.fromJSON(data);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,10 @@ importers:
       cypress:
         specifier: '>=13.0.0'
         version: 15.12.0
+    devDependencies:
+      '@types/node':
+        specifier: '*'
+        version: 25.5.0
 
   packages/jest:
     dependencies:


### PR DESCRIPTION
Fixes #2.

- Replace `new Date(raw)` with a strict `/^\d{4}-\d{2}-\d{2}$/` regex check;
  non-padded formats like "2026-4-1" (rejected by Safari) now throw a descriptive
  error with the row number instead of silently producing an invalid date.
- Parse dates as midnight UTC of the *next* day so "disabled until 2026-04-01"
  keeps the test disabled through the entire calendar day in UTC and re-enables
  exactly at 2026-04-02T00:00:00Z, regardless of the runner's local timezone.
- Update affected tests: invalid-format cases now expect a throw; date equality
  assertions updated to the new next-day-UTC values.

All 122 tests pass across all framework integrations (jest, playwright,
cypress, vitest, nightwatch).

https://claude.ai/code/session_01HTX5hH2i32tQn5kTzaNmWq